### PR TITLE
feat: added page.handleEvent function

### DIFF
--- a/packages/move-style/src/ComponentEventHandler.ts
+++ b/packages/move-style/src/ComponentEventHandler.ts
@@ -4,6 +4,8 @@ import { Page } from "./Page";
 import { Scope } from "./Scope";
 import { HttpRequestOptions } from "./types/request-types";
 import {
+  IPage,
+  IScope,
   RockEvent,
   RockEventHandler,
   RockEventHandlerHandleEvent,
@@ -27,7 +29,15 @@ import { AxiosResponse } from "axios";
 
 // TODO: make event handling extensible.
 
-export async function handleComponentEvent(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandlerOrHandlers: RockEventHandler | RockEventHandler[], eventArgs: any[]) {
+export async function handleComponentEvent(
+  eventName: string,
+  framework: Framework,
+  page: IPage,
+  scope: IScope,
+  sender: any,
+  eventHandlerOrHandlers: RockEventHandler | RockEventHandler[],
+  eventArgs: any[],
+) {
   if (!eventHandlerOrHandlers) {
     return;
   }
@@ -54,7 +64,15 @@ export async function handleComponentEvent(eventName: string, framework: Framewo
   }
 }
 
-async function doHandleComponentEvent(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandler, eventArgs: any[]) {
+async function doHandleComponentEvent(
+  eventName: string,
+  framework: Framework,
+  page: IPage,
+  scope: IScope,
+  sender: any,
+  eventHandler: RockEventHandler,
+  eventArgs: any[],
+) {
   const action = eventHandler.$action;
   const event: RockEvent = {
     framework,
@@ -132,7 +150,15 @@ const compileFunc = memoize(function (script) {
   return new Function(`return async function(event) { ${script} }`)();
 });
 
-async function handleScript(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandlerScript, eventArgs: any[]) {
+async function handleScript(
+  eventName: string,
+  framework: Framework,
+  page: Page,
+  scope: Scope,
+  sender: any,
+  eventHandler: RockEventHandlerScript,
+  eventArgs: any[],
+) {
   const event: RockEvent = {
     framework,
     page,
@@ -150,7 +176,15 @@ async function handleScript(eventName: string, framework: Framework, page: Page,
   await script(event);
 }
 
-async function handleThrowError(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandlerThrowError, eventArgs: any[]) {
+async function handleThrowError(
+  eventName: string,
+  framework: Framework,
+  page: Page,
+  scope: Scope,
+  sender: any,
+  eventHandler: RockEventHandlerThrowError,
+  eventArgs: any[],
+) {
   const err = new Error(eventHandler.message, { cause: eventHandler.cause });
   if (eventHandler.name) {
     err.name = eventHandler.name;
@@ -158,7 +192,15 @@ async function handleThrowError(eventName: string, framework: Framework, page: P
   throw err;
 }
 
-async function handleWait(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandlerWait, eventArgs: any[]) {
+async function handleWait(
+  eventName: string,
+  framework: Framework,
+  page: Page,
+  scope: Scope,
+  sender: any,
+  eventHandler: RockEventHandlerWait,
+  eventArgs: any[],
+) {
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve(null);
@@ -166,11 +208,27 @@ async function handleWait(eventName: string, framework: Framework, page: Page, s
   });
 }
 
-async function handleHandleEvent(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandlerHandleEvent, eventArgs: any[]) {
+async function handleHandleEvent(
+  eventName: string,
+  framework: Framework,
+  page: Page,
+  scope: Scope,
+  sender: any,
+  eventHandler: RockEventHandlerHandleEvent,
+  eventArgs: any[],
+) {
   await handleComponentEvent(eventHandler.eventName, framework, page as any, eventHandler.scope || scope, sender, eventHandler.handlers, eventHandler.args);
 }
 
-async function handleNotifyEvent(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandlerNotifyEvent, eventArgs: any[]) {
+async function handleNotifyEvent(
+  eventName: string,
+  framework: Framework,
+  page: Page,
+  scope: Scope,
+  sender: any,
+  eventHandler: RockEventHandlerNotifyEvent,
+  eventArgs: any[],
+) {
   const { scopeId } = eventHandler;
   let targetScope = scope;
   if (scopeId) {
@@ -192,7 +250,15 @@ async function handleNotifyEvent(eventName: string, framework: Framework, page: 
   await targetScope.notifyEvent(eventToNotify);
 }
 
-async function handleNotifyToPage(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandlerNotifyToPage, eventArgs: any[]) {
+async function handleNotifyToPage(
+  eventName: string,
+  framework: Framework,
+  page: Page,
+  scope: Scope,
+  sender: any,
+  eventHandler: RockEventHandlerNotifyToPage,
+  eventArgs: any[],
+) {
   const eventToNotify: RockEvent = {
     framework,
     page,
@@ -205,7 +271,15 @@ async function handleNotifyToPage(eventName: string, framework: Framework, page:
   await page.notifyEvent(eventToNotify);
 }
 
-function handleSetComponentProperty(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandlerSetComponentProperty, eventArgs: any[]) {
+function handleSetComponentProperty(
+  eventName: string,
+  framework: Framework,
+  page: Page,
+  scope: Scope,
+  sender: any,
+  eventHandler: RockEventHandlerSetComponentProperty,
+  eventArgs: any[],
+) {
   let { propValue } = eventHandler;
   if (typeof propValue === "function") {
     propValue = propValue(eventArgs);
@@ -214,7 +288,15 @@ function handleSetComponentProperty(eventName: string, framework: Framework, pag
   page.setComponentProperty(eventHandler.componentId, eventHandler.propName, propValue);
 }
 
-function handleSetComponentProperties(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandlerSetComponentProperties, eventArgs: any[]) {
+function handleSetComponentProperties(
+  eventName: string,
+  framework: Framework,
+  page: Page,
+  scope: Scope,
+  sender: any,
+  eventHandler: RockEventHandlerSetComponentProperties,
+  eventArgs: any[],
+) {
   let { props } = eventHandler;
   const propsToSet = {};
   for (const propName in props) {
@@ -229,15 +311,39 @@ function handleSetComponentProperties(eventName: string, framework: Framework, p
   page.setComponentProperties(eventHandler.componentId, propsToSet);
 }
 
-function handleRemoveComponentProperty(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandlerRemoveComponentProperty, eventArgs: any[]) {
+function handleRemoveComponentProperty(
+  eventName: string,
+  framework: Framework,
+  page: Page,
+  scope: Scope,
+  sender: any,
+  eventHandler: RockEventHandlerRemoveComponentProperty,
+  eventArgs: any[],
+) {
   page.removeComponentProperty(eventHandler.componentId, eventHandler.propName);
 }
 
-function handleSendComponentMessage(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandlerSendComponentMessage, eventArgs: any[]) {
+function handleSendComponentMessage(
+  eventName: string,
+  framework: Framework,
+  page: Page,
+  scope: Scope,
+  sender: any,
+  eventHandler: RockEventHandlerSendComponentMessage,
+  eventArgs: any[],
+) {
   page.sendComponentMessage(eventHandler.componentId, eventHandler.message);
 }
 
-async function handleSendHttpRequest(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandlerSendHttpRequest, eventArgs: any[]) {
+async function handleSendHttpRequest(
+  eventName: string,
+  framework: Framework,
+  page: Page,
+  scope: Scope,
+  sender: any,
+  eventHandler: RockEventHandlerSendHttpRequest,
+  eventArgs: any[],
+) {
   const { onError, onSuccess, silentOnError } = eventHandler;
   let res: AxiosResponse<any, any>;
   try {
@@ -263,7 +369,15 @@ async function handleSendHttpRequest(eventName: string, framework: Framework, pa
   }
 }
 
-async function handleSetVars(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandlerSetVars, eventArgs: any[]) {
+async function handleSetVars(
+  eventName: string,
+  framework: Framework,
+  page: Page,
+  scope: Scope,
+  sender: any,
+  eventHandler: RockEventHandlerSetVars,
+  eventArgs: any[],
+) {
   const { name, value, vars, scopeId } = eventHandler;
   let targetScope = scope;
   if (scopeId) {
@@ -285,7 +399,15 @@ async function handleSetVars(eventName: string, framework: Framework, page: Page
   }
 }
 
-async function handleLoadStoreData(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandlerLoadStoreData, eventArgs: any[]) {
+async function handleLoadStoreData(
+  eventName: string,
+  framework: Framework,
+  page: Page,
+  scope: Scope,
+  sender: any,
+  eventHandler: RockEventHandlerLoadStoreData,
+  eventArgs: any[],
+) {
   const { storeName, input, scopeId } = eventHandler;
   let targetScope = scope;
   if (scopeId) {
@@ -300,7 +422,15 @@ async function handleLoadStoreData(eventName: string, framework: Framework, page
   }
 }
 
-async function handleLoadScopeData(eventName: string, framework: Framework, page: Page, scope: Scope, sender: any, eventHandler: RockEventHandlerLoadScopeData, eventArgs: any[]) {
+async function handleLoadScopeData(
+  eventName: string,
+  framework: Framework,
+  page: Page,
+  scope: Scope,
+  sender: any,
+  eventHandler: RockEventHandlerLoadScopeData,
+  eventArgs: any[],
+) {
   const { scopeId } = eventHandler;
   let targetScope = scope;
   if (scopeId) {

--- a/packages/move-style/src/Page.ts
+++ b/packages/move-style/src/Page.ts
@@ -1,12 +1,23 @@
 import _, { each } from "lodash";
 import { ComponentTreeManager } from "./ComponentTreeManager";
 import { ExpressionInterpreter } from "./ExpressionInterpreter";
-import { RockConfig, RockPropValue, RuiEvent, PageCommand, PageConfig, IPage, RockPageEventSubscriptionConfig, RockMessage } from "./types/rock-types";
+import {
+  RockConfig,
+  RockPropValue,
+  RuiEvent,
+  PageCommand,
+  PageConfig,
+  IPage,
+  RockPageEventSubscriptionConfig,
+  RockMessage,
+  HandleRockEventOptions,
+} from "./types/rock-types";
 import { StoreConfig, IStore, StoreConfigBase } from "./types/store-types";
 import { HttpRequestInput } from "./types/request-types";
 import { Framework } from "./Framework";
 import { Scope } from "./Scope";
 import { RuiModuleLogger } from "./Logger";
+import { handleComponentEvent } from "./ComponentEventHandler";
 
 export class Page implements IPage {
   #framework: Framework;
@@ -187,5 +198,15 @@ export class Page implements IPage {
 
   async notifyEvent(event: RuiEvent) {
     this.scope.notifyEvent(event);
+  }
+
+  async handleEvent(options: HandleRockEventOptions) {
+    const { eventName, context, parentEvent, sender, handlers, args } = options;
+    if (!context && !parentEvent) {
+      throw new Error(`"context" or "parentEvent" must be provided.`);
+    }
+
+    let { framework, page, scope } = context || parentEvent;
+    await handleComponentEvent(eventName, framework, page, scope, sender || {}, handlers, args || []);
   }
 }

--- a/packages/move-style/src/types/rock-types.ts
+++ b/packages/move-style/src/types/rock-types.ts
@@ -289,12 +289,29 @@ export type RuiEvent = RockEvent;
 export type RockEvent = {
   framework: Framework;
   page: IPage;
-  scope: Scope;
+  scope: IScope;
   name: string;
   senderCategory: "component";
   sender: any;
   args: any[];
 };
+
+export type RockEventSender = RockInstance;
+
+export interface HandleRockEventContext {
+  framework: Framework;
+  page: IPage;
+  scope: IScope;
+}
+
+export interface HandleRockEventOptions {
+  context?: HandleRockEventContext;
+  parentEvent?: RockEvent;
+  eventName?: string;
+  sender?: RockEventSender;
+  handlers: RockEventHandlerConfig;
+  args?: any[];
+}
 
 export type RockPageEventSubscriptionConfig = {
   eventName: string;
@@ -686,11 +703,15 @@ export type PageCommandRemoveStep = {
 };
 
 export interface IPage {
+  get scope(): IScope;
+
   generateComponentId(type: string);
 
   setConfig(pageConfig: PageConfig);
 
   getConfig(): PageConfig;
+
+  interpreteExpression(expressionString: string, rootVars: Record<string, any>): any;
 
   addComponents(components: RockConfig[], parentComponentId?: string, slotPropName?: string, prevSiblingComponentId?: string);
 
@@ -721,6 +742,26 @@ export interface IPage {
   notifyEvent(event: RuiEvent);
 
   sendComponentMessage<TRockMessage extends RockMessage<any> = RockMessage<any>>(componentId: string, message: TRockMessage);
+
+  /**
+   * 处理事件
+   * @param options
+   * @example
+   * ```
+   *  page.handleEvent({
+   *    parentEvent: event,
+   *    handlers: [
+   *      {
+   *        $action: "setComponentProperty",
+   *        componentId: "text1",
+   *        propName: "text",
+   *        propValue: "hello"
+   *      }
+   *    ]
+   *  })
+   * ```
+   */
+  handleEvent(options: HandleRockEventOptions): Promise<void>;
 }
 
 //////////////


### PR DESCRIPTION
可以在 $action: script 中调用page.handleEvent进行事件处理
```
{
  $action: "script",
  script: `
    event.page.handleEvent({
      parentEvent: event,
      handlers: [
        {
          $action: "setComponentProperty",
          componentId: "text1",
          propName: "text",
          propValue: "hello"
        }
      ]
    })
  `
```